### PR TITLE
fix kotlin version in build

### DIFF
--- a/ZenJourney/build.gradle
+++ b/ZenJourney/build.gradle
@@ -2,5 +2,5 @@
 plugins {
   id 'com.android.application' version '7.4.2' apply false
   id 'com.android.library' version '7.4.2' apply false
-  id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+  id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
 }


### PR DESCRIPTION
This version (1.1.1) of the Compose Compiler requires Kotlin version 1.6.10 but you appear to be using Kotlin version 1.6.21